### PR TITLE
fix(aot): Fixed Angular AoT compilation issue

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,8 +13,9 @@
 # Build: Temp folder
 /temp
 
-# Demo
+# Demo & docs
 /demo
+/docs
 
 # Not needed files
 /tools

--- a/src/components/notifier-container.component.ts
+++ b/src/components/notifier-container.component.ts
@@ -33,6 +33,11 @@ import { NotifierNotificationComponent } from './notifier-notification.component
 export class NotifierContainerComponent implements OnDestroy, OnInit {
 
 	/**
+	 * List of currently somewhat active notifications
+	 */
+	public notifications: Array<NotifierNotification>;
+
+	/**
 	 * Change detector
 	 */
 	private readonly changeDetector: ChangeDetectorRef;
@@ -46,11 +51,6 @@ export class NotifierContainerComponent implements OnDestroy, OnInit {
 	 * Notifier configuration
 	 */
 	private readonly config: NotifierConfig;
-
-	/**
-	 * List of currently somewhat active notifications
-	 */
-	private notifications: Array<NotifierNotification>;
 
 	/**
 	 * Queue service observable subscription (saved for cleanup)

--- a/src/components/notifier-notification.component.ts
+++ b/src/components/notifier-notification.component.ts
@@ -52,6 +52,11 @@ export class NotifierNotificationComponent implements AfterViewInit {
 	public dismiss: EventEmitter<string>;
 
 	/**
+	 * Notifier configuration
+	 */
+	public readonly config: NotifierConfig;
+
+	/**
 	 * Notifier timer service
 	 */
 	private readonly timerService: NotifierTimerService;
@@ -65,11 +70,6 @@ export class NotifierNotificationComponent implements AfterViewInit {
 	 * Angular renderer, used to preserve the overall DOM abstraction & independence
 	 */
 	private readonly renderer: Renderer;
-
-	/**
-	 * Notifier configuration
-	 */
-	private readonly config: NotifierConfig;
 
 	// tslint:disable no-any
 	/**

--- a/src/models/notifier-config.model.ts
+++ b/src/models/notifier-config.model.ts
@@ -108,12 +108,19 @@ export class NotifierConfig implements NotifierOptions {
 	 */
 	public theme: string;
 
+	// tslint:disable no-any
 	/**
 	 * Constructor
 	 *
-	 * @param {NotifierOptions} [customOptions={}] Custom notifier options, optional
+	 * Note:
+	 * As for now, Angular cannot handle interface declarations in constructors of injectable classes. This issue got fixed, however only
+	 * for Angular 4+. Therefore, we use the 'any' type temporarily. For further details, see
+	 * - the issue on <https://github.com/angular/angular/issues/12631> as well as
+	 * - the fix on <https://github.com/angular/angular/pull/14894>.
+	 *
+	 * @param {any} [customOptions={}] Custom notifier options, optional
 	 */
-	public constructor( customOptions: NotifierOptions = {} ) {
+	public constructor( customOptions: any = {} ) {
 
 		// Set default values
 		this.animations = {
@@ -191,5 +198,6 @@ export class NotifierConfig implements NotifierOptions {
 		}
 
 	}
+	// tslint:enable no-any
 
 }


### PR DESCRIPTION
- Fixed Angular AoT issue when compiling (resolving symbol values statically)
- Improved overall AoT compability
- Extended npmignore file

Cloes #7 