### PR TITLE
fix(notification-container): Fix wrong ngFor trackby implementation

### DIFF
--- a/src/components/notifier-container.component.html
+++ b/src/components/notifier-container.component.html
@@ -1,5 +1,5 @@
 <ul>
-	<li class="x-notifier__container-list" *ngFor="let notification of notifications; trackBy: notification?.id">
+	<li class="x-notifier__container-list" *ngFor="let notification of notifications; trackBy: identifyNotification;">
 		<x-notifier-notification
 			[notification]="notification"
 			(ready)="onNotificationReady( $event )"

--- a/src/components/notifier-container.component.ts
+++ b/src/components/notifier-container.component.ts
@@ -97,6 +97,17 @@ export class NotifierContainerComponent implements OnDestroy, OnInit {
 	}
 
 	/**
+	 * Notification identifier, used as the ngFor trackby function
+	 *
+	 * @param   {number}               index        Index
+	 * @param   {NotifierNotification} notification Notifier notification
+	 * @returns {string}                            Notification ID as the unique identnfier
+	 */
+	public identifyNotification( index: number, notification: NotifierNotification ): string {
+		return notification.id;
+	}
+
+	/**
 	 * Event handler, handles clicks on notification dismiss buttons
 	 *
 	 * @param {string} notificationId ID of the notification to dismiss


### PR DESCRIPTION
- Fix wrong ngFor trackby implementation by replacing the direct value access with a class method

Closes #12.