### PR TITLE
chore(dependencies): Update NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,17 +39,16 @@
         "coveralls": "cat ./test-coverage/ts/lcov.info | coveralls"
     },
     "peerDependencies": {
-        "@angular/core": "2.x",
-        "@angular/common": "2.x",
-        "rxjs": "5.0.1"
+        "@angular/core": ">= 2.0.0 < 5.0.0",
+        "@angular/common": ">= 2.0.0 < 5.0.0"
     },
     "devDependencies": {
-        "@angular/core": "2.x",
-        "@angular/common": "2.x",
-        "@angular/compiler": "2.x",
-        "@angular/compiler-cli": "2.x",
-        "@angular/platform-browser": "2.x",
-        "@angular/platform-browser-dynamic": "2.x",
+        "@angular/core": "2.4.x",
+        "@angular/common": "2.4.x",
+        "@angular/compiler": "2.4.x",
+        "@angular/compiler-cli": "2.4.x",
+        "@angular/platform-browser": "2.4.x",
+        "@angular/platform-browser-dynamic": "2.4.x",
         "@types/jasmine": "2.5.x",
         "browser-sync": "2.18.x",
         "codelyzer": "2.0.0-beta.4",


### PR DESCRIPTION
This PR allows **angular-notifier** to be used with the all new Angular 4; however, it doesn't use the new APIs. Therefore, no breaking changes exist.