### PR TITLE
style(type-colors) use bootstrap colors for notification types

### DIFF
--- a/src/styles/types/type-error.scss
+++ b/src/styles/types/type-error.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: ERROR TYPE STYLES
 
-$notifier-error-background-color: #d9534f;
+$notifier-error-background-color: #D9534F;
 $notifier-error-font-color: #FFF;
 $notifier-error-icon-color: #FFF;
 

--- a/src/styles/types/type-error.scss
+++ b/src/styles/types/type-error.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: ERROR TYPE STYLES
 
-$notifier-error-background-color: #BF4654;
+$notifier-error-background-color: #d9534f;
 $notifier-error-font-color: #FFF;
 $notifier-error-icon-color: #FFF;
 

--- a/src/styles/types/type-info.scss
+++ b/src/styles/types/type-info.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: INFO TYPE STYLES
 
-$notifier-info-background-color: #5bc0de;
+$notifier-info-background-color: #5BC0DE;
 $notifier-info-font-color: #FFF;
 $notifier-info-icon-color: #FFF;
 

--- a/src/styles/types/type-info.scss
+++ b/src/styles/types/type-info.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: INFO TYPE STYLES
 
-$notifier-info-background-color: #2B90D9;
+$notifier-info-background-color: #5bc0de;
 $notifier-info-font-color: #FFF;
 $notifier-info-icon-color: #FFF;
 

--- a/src/styles/types/type-success.scss
+++ b/src/styles/types/type-success.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: SUCCESS TYPE STYLES
 
-$notifier-success-background-color: #A08E5D;
+$notifier-success-background-color: #5cb85c;
 $notifier-success-font-color: #FFF;
 $notifier-success-icon-color: #FFF;
 

--- a/src/styles/types/type-success.scss
+++ b/src/styles/types/type-success.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: SUCCESS TYPE STYLES
 
-$notifier-success-background-color: #5cb85c;
+$notifier-success-background-color: #5CB85C;
 $notifier-success-font-color: #FFF;
 $notifier-success-icon-color: #FFF;
 

--- a/src/styles/types/type-warning.scss
+++ b/src/styles/types/type-warning.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: WARNING TYPE STYLES
 
-$notifier-warning-background-color: #CCA757;
+$notifier-warning-background-color: #f0ad4e;
 $notifier-warning-font-color: #FFF;
 $notifier-warning-icon-color: #FFF;
 

--- a/src/styles/types/type-warning.scss
+++ b/src/styles/types/type-warning.scss
@@ -1,6 +1,6 @@
 // NOTIFIER: WARNING TYPE STYLES
 
-$notifier-warning-background-color: #f0ad4e;
+$notifier-warning-background-color: #F0AD4E;
 $notifier-warning-font-color: #FFF;
 $notifier-warning-icon-color: #FFF;
 


### PR DESCRIPTION
This PR resolves #11
![notifier](https://cloud.githubusercontent.com/assets/10798986/24643192/c287d50e-1925-11e7-8fe7-c5b014ded675.png)
