### PR TITLE
feat(angular): Upgrade to Angular 4 and its new APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,16 +39,16 @@
         "coveralls": "cat ./test-coverage/ts/lcov.info | coveralls"
     },
     "peerDependencies": {
-        "@angular/core": ">= 2.0.0 < 5.0.0",
-        "@angular/common": ">= 2.0.0 < 5.0.0"
+        "@angular/core": ">= 4.0.0 < 5.0.0",
+        "@angular/common": ">= 4.0.0 < 5.0.0"
     },
     "devDependencies": {
-        "@angular/core": "2.4.x",
-        "@angular/common": "2.4.x",
-        "@angular/compiler": "2.4.x",
-        "@angular/compiler-cli": "2.4.x",
-        "@angular/platform-browser": "2.4.x",
-        "@angular/platform-browser-dynamic": "2.4.x",
+        "@angular/core": "4.0.x",
+        "@angular/common": "4.0.x",
+        "@angular/compiler": "4.0.x",
+        "@angular/compiler-cli": "4.0.x",
+        "@angular/platform-browser": "4.0.x",
+        "@angular/platform-browser-dynamic": "4.0.x",
         "@types/jasmine": "2.5.x",
         "browser-sync": "2.18.x",
         "codelyzer": "2.0.0-beta.4",
@@ -85,13 +85,13 @@
         "reflect-metadata": "0.1.x",
         "remap-istanbul": "0.8.x",
         "require-dir": "0.3.x",
-        "rxjs": "5.1.x",
+        "rxjs": "5.3.x",
         "source-map-loader": "0.1.x",
         "systemjs": "0.20.x",
         "tslint": "4.4.x",
         "typescript": "2.0.x",
         "web-animations-js": "2.2.x",
         "webpack": "2.2.x",
-        "zone.js": "0.7.x"
+        "zone.js": "0.8.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
         "source-map-loader": "0.1.x",
         "systemjs": "0.20.x",
         "tslint": "4.4.x",
-        "typescript": "2.0.x",
+        "typescript": "2.2.x",
         "web-animations-js": "2.2.x",
         "webpack": "2.2.x",
         "zone.js": "0.8.5"

--- a/src/notifier.module.ts
+++ b/src/notifier.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ModuleWithProviders, NgModule, OpaqueToken } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
 
 import { NotifierContainerComponent } from './components/notifier-container.component';
 import { NotifierNotificationComponent } from './components/notifier-notification.component';
@@ -12,7 +12,7 @@ import { NotifierService } from './services/notifier.service';
 /**
  * Dependency Injection token for custom notifier options
  */
-export const CustomNotifierOptions: OpaqueToken = new OpaqueToken( 'NotifierOptions' );
+export const CustomNotifierOptions: InjectionToken<string> = new InjectionToken<string>( 'NotifierOptions' );
 // tslint:enable variable-name
 
 /**


### PR DESCRIPTION
- Upgrade Angular dependencies (incl. its peer dependencies)
- Use the new Renderer 2 instead of Renderer
- Use InjectionToken instead of OpaqueToken

BREAKING CHANGE: Upgrade to Angular 4 and its APIs breaks compatibility with Angular 2 applications.