### PR TITLE
fix(notifier-config): Fix notifier config injection error, refactor notifier module

### DIFF
--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -61,7 +61,7 @@ const customNotifierOptions: NotifierOptions = {
 	],
 	imports: [
 		BrowserModule,
-		NotifierModule.forRoot( customNotifierOptions )
+		NotifierModule.withConfig( customNotifierOptions )
 	]
 } )
 export class AppModule {}

--- a/src/lib/src/components/notifier-container.component.spec.ts
+++ b/src/lib/src/components/notifier-container.component.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 
 import { Subject } from 'rxjs/Rx';
 
+import { NotifierConfigToken } from '../notifier.module';
 import { NotifierNotification } from '../models/notifier-notification.model';
 import { NotifierAction } from '../models/notifier-action.model';
 import { NotifierConfig } from '../models/notifier-config.model';
@@ -1010,6 +1011,10 @@ describe( 'Notifier Container Component', () => {
 					useValue: {
 						getConfig: () => testNotifierConfig
 					}
+				},
+				{ // No idea why this is *actually* necessary -- it shouldn't be ...
+					provide: NotifierConfigToken,
+					useValue: {}
 				},
 				{
 					provide: NotifierQueueService,

--- a/src/lib/src/components/notifier-notification.component.spec.ts
+++ b/src/lib/src/components/notifier-notification.component.spec.ts
@@ -2,6 +2,7 @@ import { DebugElement, ElementRef, Provider, Renderer } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
 
+import { NotifierConfigToken } from '../notifier.module';
 import { NotifierAnimationData } from '../models/notifier-animation.model';
 import { NotifierNotification } from '../models/notifier-notification.model';
 import { NotifierConfig } from '../models/notifier-config.model';
@@ -941,6 +942,10 @@ describe( 'Notifier Notification Component', () => {
 						useValue: {
 							getConfig: () => testNotifierConfig
 						}
+					},
+					{ // No idea why this is *actually* necessary -- it shouldn't be ...
+						provide: NotifierConfigToken,
+						useValue: {}
 					},
 					{
 						provide: NotifierAnimationService,

--- a/src/lib/src/models/notifier-config.model.ts
+++ b/src/lib/src/models/notifier-config.model.ts
@@ -1,5 +1,3 @@
-import { Injectable } from '@angular/core';
-
 /**
  * Notifier options
  */
@@ -51,7 +49,6 @@ export interface NotifierOptions {
  * configuration, which means that it only can be set once (at the beginning), and cannot be changed afterwards. Aligning to the world of
  * Angular, this configuration can be provided in the root app module - alternatively, a meaningful default configuration will be used.
  */
-@Injectable()
 export class NotifierConfig implements NotifierOptions {
 
 	/**
@@ -108,19 +105,12 @@ export class NotifierConfig implements NotifierOptions {
 	 */
 	public theme: string;
 
-	// tslint:disable no-any
 	/**
 	 * Constructor
 	 *
-	 * Note:
-	 * As for now, Angular cannot handle interface declarations in constructors of injectable classes. This issue got fixed, however only
-	 * for Angular 4+. Therefore, we use the 'any' type temporarily. For further details, see
-	 * - the issue on <https://github.com/angular/angular/issues/12631> as well as
-	 * - the fix on <https://github.com/angular/angular/pull/14894>.
-	 *
-	 * @param {any} [customOptions={}] Custom notifier options, optional
+	 * @param {NotifierOptions} [customOptions={}] Custom notifier options, optional
 	 */
-	public constructor( customOptions: any = {} ) {
+	public constructor( customOptions: NotifierOptions = {} ) {
 
 		// Set default values
 		this.animations = {
@@ -198,6 +188,5 @@ export class NotifierConfig implements NotifierOptions {
 		}
 
 	}
-	// tslint:enable no-any
 
 }

--- a/src/lib/src/notifier.module.spec.ts
+++ b/src/lib/src/notifier.module.spec.ts
@@ -101,7 +101,7 @@ describe( 'Notifier Module', () => {
 
 		TestBed.configureTestingModule( {
 			imports: [
-				NotifierModule.forRoot( testNotifierOptions )
+				NotifierModule.withConfig( testNotifierOptions )
 			]
 		} );
 		let service: NotifierService = TestBed.get( NotifierService );

--- a/src/lib/src/notifier.module.ts
+++ b/src/lib/src/notifier.module.ts
@@ -84,7 +84,7 @@ export class NotifierModule {
 	 * @param   {NotifierOptions}     [options={}] - Custom notifier options
 	 * @returns {ModuleWithProviders}              - Notifier module with custom providers
 	 */
-	public static forRoot( options: NotifierOptions = {} ): ModuleWithProviders {
+	public static withConfig( options: NotifierOptions = {} ): ModuleWithProviders {
 		return {
 			ngModule: NotifierModule,
 			providers: [

--- a/src/lib/src/notifier.module.ts
+++ b/src/lib/src/notifier.module.ts
@@ -9,23 +9,44 @@ import { NotifierQueueService } from './services/notifier-queue.service';
 import { NotifierService } from './services/notifier.service';
 
 // tslint:disable variable-name
+
 /**
- * Dependency Injection token for custom notifier options
+ * Injection Token for notifier options
  */
-export const CustomNotifierOptions: InjectionToken<string> = new InjectionToken<string>( 'NotifierOptions' );
+export const NotifierOptionsToken: InjectionToken<NotifierOptions>
+	= new InjectionToken<NotifierOptions>( '[angular-notifier] Notifier Options' );
+
+/**
+ * Injection Token for notifier configuration
+ */
+export const NotifierConfigToken: InjectionToken<NotifierConfig>
+	= new InjectionToken<NotifierConfig>( '[anuglar-notifier] Notifier Config' );
+
 // tslint:enable variable-name
 
 /**
- * Factory for creating a notifier configuration object
+ * Factory for a notifier configuration with custom options
  *
  * Sidenote:
- * This functionality had to be extracted from the NotifierModule.forRoot function, described below. Otherwhise, the Angular AoT compiler
- * would throw errors. For further details, also see:
- * - Angular issue #11262 <https://github.com/angular/angular/issues/11262>
- * - Angular issue #10789 <https://github.com/angular/angular/issues/10789>
+ * Required as Angular AoT compilation cannot handle dynamic functions; see <https://github.com/angular/angular/issues/11262>.
+ *
+ * @param   {NotifierOptions} options - Custom notifier options
+ * @returns {NotifierConfig}          - Notifier configuration as result
  */
-export function notifierConfigFactory( options: NotifierOptions ): NotifierConfig {
+export function notifierCustomConfigFactory( options: NotifierOptions ): NotifierConfig {
 	return new NotifierConfig( options );
+}
+
+/**
+ * Factory for a notifier configuration with default options
+ *
+ * Sidenote:
+ * Required as Angular AoT compilation cannot handle dynamic functions; see <https://github.com/angular/angular/issues/11262>.
+ *
+ * @returns {NotifierConfig} - Notifier configuration as result
+ */
+export function notifierDefaultConfigFactory(): NotifierConfig {
+	return new NotifierConfig( {} );
 }
 
 /**
@@ -45,29 +66,44 @@ export function notifierConfigFactory( options: NotifierOptions ): NotifierConfi
 	providers: [
 		NotifierAnimationService,
 		NotifierService,
-		NotifierQueueService
+		NotifierQueueService,
+
+		// Provide the default notifier configuration if just the module is imported
+		{
+			provide: NotifierConfigToken,
+			useFactory: notifierDefaultConfigFactory
+		}
+
 	]
 } )
 export class NotifierModule {
 
 	/**
-	 * Setup custom module (service) configuration
+	 * Setup the notifier module with custom providers, in this case with a custom configuration based on the givne options
+	 *
+	 * @param   {NotifierOptions}     [options={}] - Custom notifier options
+	 * @returns {ModuleWithProviders}              - Notifier module with custom providers
 	 */
-	public static forRoot( options: NotifierOptions ): ModuleWithProviders {
+	public static forRoot( options: NotifierOptions = {} ): ModuleWithProviders {
 		return {
 			ngModule: NotifierModule,
 			providers: [
+
+				// Provide the options itself upfront (as we need to inject them as dependencies -- see below)
 				{
-					provide: CustomNotifierOptions,
+					provide: NotifierOptionsToken,
 					useValue: options
 				},
+
+				// Provide a custom notifier configuration, based on the given notifier options
 				{
 					deps: [
-						CustomNotifierOptions
+						NotifierOptionsToken
 					],
-					provide: NotifierConfig,
-					useFactory: notifierConfigFactory
+					provide: NotifierConfigToken,
+					useFactory: notifierCustomConfigFactory
 				}
+
 			]
 		};
 	}

--- a/src/lib/src/services/notifier.service.spec.ts
+++ b/src/lib/src/services/notifier.service.spec.ts
@@ -1,5 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 
+import { NotifierConfigToken } from '../notifier.module';
 import { NotifierConfig } from '../models/notifier-config.model';
 import { NotifierNotificationOptions } from '../models/notifier-notification.model';
 import { NotifierAction } from '../models/notifier-action.model';
@@ -9,7 +10,7 @@ import { NotifierService } from './notifier.service';
 /**
  * Notifier Service - Unit Test
  */
-const testNotifierConfig: NotifierConfig = {
+const testNotifierConfig: NotifierConfig = new NotifierConfig( {
 	animations: {
 		enabled: true,
 		hide: {
@@ -48,7 +49,7 @@ const testNotifierConfig: NotifierConfig = {
 		}
 	},
 	theme: 'material'
-};
+} );
 
 describe( 'Notifier Service', () => {
 
@@ -65,7 +66,7 @@ describe( 'Notifier Service', () => {
 					useClass: MockNotifierQueueService
 				},
 				{
-					provide: NotifierConfig,
+					provide: NotifierConfigToken,
 					useValue: testNotifierConfig
 				}
 			]

--- a/src/lib/src/services/notifier.service.ts
+++ b/src/lib/src/services/notifier.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Optional } from '@angular/core';
+import { forwardRef, Inject, Injectable, Optional } from '@angular/core';
 
 import { NotifierConfig } from './../models/notifier-config.model';
 import { NotifierNotificationOptions } from './../models/notifier-notification.model';
 import { NotifierQueueService } from './notifier-queue.service';
+import { NotifierConfigToken } from './../notifier.module';
 
 /**
  * Notifier service
@@ -30,9 +31,12 @@ export class NotifierService {
 	 * @param {NotifierQueueService} notifierQueueService Notifier queue service
 	 * @param {NotifierConfig}       config               Notifier configuration, optionally injected as a dependency
 	 */
-	public constructor( notifierQueueService: NotifierQueueService, @Optional() config: NotifierConfig ) {
+	public constructor(
+		notifierQueueService: NotifierQueueService,
+		@Inject( forwardRef( () => NotifierConfigToken ) ) config: NotifierConfig // The forwardRef is (sadly) required here
+	) {
 		this.queueService = notifierQueueService;
-		this.config = config === null ? new NotifierConfig() : config; // Use custom config (if set), else create a default config
+		this.config = config;
 	}
 
 	/**

--- a/tslint.json
+++ b/tslint.json
@@ -227,7 +227,7 @@
 		"no-attribute-parameter-decorator": true,
 		"no-input-rename": true,
 		"no-output-rename": true,
-		"no-forward-ref": true,
+		"no-forward-ref": false,
 		"use-life-cycle-interface": true,
 		"use-pipe-transform-interface": true,
 		"pipe-naming": [


### PR DESCRIPTION
- Fix error / warning occuring during the injection of the notifier config
- Refactor injection tokens
- Refactor notifier module

Closes #17.
BREAKING CHANGE: The forRoot() method of the NotifierModule is now called withConfig() (see MIGRATION GUIDE).