### PR TITLE
refactor(naming): Refactor namings to no longer use the "x-" prefix

### DIFF
--- a/src/demo/app.component.ts
+++ b/src/demo/app.component.ts
@@ -49,7 +49,7 @@ import { NotifierService } from './../lib/index';
 			Hide notification with ID named 'ID_TEST'
 		</button>
 
-		<x-notifier-container></x-notifier-container>
+		<notifier-container></notifier-container>
 	`
 } )
 export class AppComponent {

--- a/src/lib/src/components/notifier-container.component.html
+++ b/src/lib/src/components/notifier-container.component.html
@@ -1,9 +1,9 @@
 <ul>
-	<li class="x-notifier__container-list" *ngFor="let notification of notifications; trackBy: identifyNotification;">
-		<x-notifier-notification
+	<li class="notifier__container-list" *ngFor="let notification of notifications; trackBy: identifyNotification;">
+		<notifier-notification
 			[notification]="notification"
 			(ready)="onNotificationReady( $event )"
 			(dismiss)="onNotificationDismiss( $event )">
-		</x-notifier-notification>
+		</notifier-notification>
 	</li>
 </ul>

--- a/src/lib/src/components/notifier-container.component.spec.ts
+++ b/src/lib/src/components/notifier-container.component.spec.ts
@@ -76,7 +76,7 @@ describe( 'Notifier Container Component', () => {
 				type: 'SHOW'
 			} );
 			componentFixture.detectChanges();
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			expect( listElements.length ).toBe( 1 );
 
@@ -397,7 +397,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			expect( listElements.length ).toBe( 0 );
 			expect( mockNotificationComponent.hide ).toHaveBeenCalled();
@@ -443,7 +443,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			let listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			let listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			expect( listElements.length ).toBe( 1 );
 			expect( mockNotificationComponent.hide ).not.toHaveBeenCalled();
@@ -504,7 +504,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 1 );
@@ -568,7 +568,7 @@ describe( 'Notifier Container Component', () => {
 			tick( testNotifierConfig.animations.hide.speed );
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 1 );
@@ -628,7 +628,7 @@ describe( 'Notifier Container Component', () => {
 			tick( testNotifierConfig.animations.hide.speed - <number> testNotifierConfig.animations.overlap );
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 1 );
@@ -671,7 +671,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges();
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 2;
 			expect( listElements.length ).toBe( 0 );
@@ -735,7 +735,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 1 );
@@ -818,7 +818,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 1 );
@@ -904,7 +904,7 @@ describe( 'Notifier Container Component', () => {
 			tick();
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 0 );
@@ -962,7 +962,7 @@ describe( 'Notifier Container Component', () => {
 			tick( testNotifierConfig.animations.hide.speed + ( numberOfNotifications * <number> testNotifierConfig.animations.hide.offset ) );
 			componentFixture.detectChanges(); // Run a second change detection (to update the template)
 
-			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.x-notifier__container-list' ) );
+			const listElements: Array<DebugElement> = componentFixture.debugElement.queryAll( By.css( '.notifier__container-list' ) );
 
 			const expectedCallTimes: number = 3;
 			expect( listElements.length ).toBe( 0 );

--- a/src/lib/src/components/notifier-container.component.ts
+++ b/src/lib/src/components/notifier-container.component.ts
@@ -25,9 +25,9 @@ import { NotifierNotificationComponent } from './notifier-notification.component
 @Component( {
 	changeDetection: ChangeDetectionStrategy.OnPush, // (#perfmatters)
 	host: {
-		class: 'x-notifier__container'
+		class: 'notifier__container'
 	},
-	selector: 'x-notifier-container',
+	selector: 'notifier-container',
 	templateUrl: './notifier-container.component.html'
 } )
 export class NotifierContainerComponent implements OnDestroy, OnInit {

--- a/src/lib/src/components/notifier-notification.component.html
+++ b/src/lib/src/components/notifier-notification.component.html
@@ -1,7 +1,7 @@
-<p class="x-notifier__notification-message">{{ notification.message }}</p>
-<button class="x-notifier__notification-button" type="button" title="dismiss"
+<p class="notifier__notification-message">{{ notification.message }}</p>
+<button class="notifier__notification-button" type="button" title="dismiss"
 	*ngIf="config.behaviour.showDismissButton" (click)="onClickDismiss()">
-	<svg class="x-notifier__notification-button-icon" viewBox="0 0 24 24" width="20" height="20">
+	<svg class="notifier__notification-button-icon" viewBox="0 0 24 24" width="20" height="20">
 		<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
 	</svg>
 </button>

--- a/src/lib/src/components/notifier-notification.component.spec.ts
+++ b/src/lib/src/components/notifier-notification.component.spec.ts
@@ -53,15 +53,15 @@ describe( 'Notifier Notification Component', () => {
 			expect( componentInstance.getShift() ).toBe( 0 );
 
 			// Check the template
-			const messageElement: DebugElement = componentFixture.debugElement.query( By.css( '.x-notifier__notification-message' ) );
+			const messageElement: DebugElement = componentFixture.debugElement.query( By.css( '.notifier__notification-message' ) );
 			expect( messageElement.nativeElement.textContent ).toContain( componentInstance.notification.message );
-			const dismissButtonElement: DebugElement = componentFixture.debugElement.query( By.css( '.x-notifier__notification-button' ) );
+			const dismissButtonElement: DebugElement = componentFixture.debugElement.query( By.css( '.notifier__notification-button' ) );
 			expect( dismissButtonElement ).not.toBeNull();
 
 			// Check the class names
-			const classNameType: string = `x-notifier__notification--${ componentInstance.notification.type }`;
+			const classNameType: string = `notifier__notification--${ componentInstance.notification.type }`;
 			expect( componentFixture.nativeElement.classList.contains( classNameType ) ).toBeTruthy();
-			const classNameTheme: string = `x-notifier__notification--${ componentInstance.getConfig().theme }`;
+			const classNameTheme: string = `notifier__notification--${ componentInstance.getConfig().theme }`;
 			expect( componentFixture.nativeElement.classList.contains( classNameTheme ) ).toBeTruthy();
 
 		} );
@@ -792,7 +792,7 @@ describe( 'Notifier Notification Component', () => {
 			componentInstance.show();
 			jest.spyOn( componentInstance, 'onClickDismiss' );
 
-			const dismissButtonElement: DebugElement = componentFixture.debugElement.query( By.css( '.x-notifier__notification-button' ) );
+			const dismissButtonElement: DebugElement = componentFixture.debugElement.query( By.css( '.notifier__notification-button' ) );
 			dismissButtonElement.nativeElement.click(); // Emulate click event
 			componentFixture.detectChanges();
 

--- a/src/lib/src/components/notifier-notification.component.ts
+++ b/src/lib/src/components/notifier-notification.component.ts
@@ -21,14 +21,14 @@ import { NotifierTimerService } from './../services/notifier-timer.service';
 		'(click)': 'onNotificationClick()',
 		'(mouseout)': 'onNotificationMouseout()',
 		'(mouseover)': 'onNotificationMouseover()',
-		class: 'x-notifier__notification'
+		class: 'notifier__notification'
 	},
 	providers: [
 		// We provide the timer to the component's local injector, so that every notification components gets its own
 		// instance of the timer service, thus running their timers independently from each other
 		NotifierTimerService
 	],
-	selector: 'x-notifier-notification',
+	selector: 'notifier-notification',
 	templateUrl: './notifier-notification.component.html'
 } )
 export class NotifierNotificationComponent implements AfterViewInit {
@@ -369,8 +369,8 @@ export class NotifierNotificationComponent implements AfterViewInit {
 		}
 
 		// Add classes (responsible for visual design)
-		this.renderer.addClass( this.element, `x-notifier__notification--${ this.notification.type }` );
-		this.renderer.addClass( this.element, `x-notifier__notification--${ this.config.theme }` );
+		this.renderer.addClass( this.element, `notifier__notification--${ this.notification.type }` );
+		this.renderer.addClass( this.element, `notifier__notification--${ this.config.theme }` );
 
 	}
 

--- a/src/lib/styles/core.scss
+++ b/src/lib/styles/core.scss
@@ -2,38 +2,40 @@
 
 // Container
 
-.x-notifier__container {
+.notifier {
 
-	* {
-		box-sizing: border-box;
+	&__container {
+
+		* {
+			box-sizing: border-box;
+		}
+
+		&-list {
+			margin: {
+				top: 0;
+				bottom: 0;
+			}
+			padding: {
+				left: 0;
+			}
+			list-style-type: none;
+		}
+
 	}
 
-}
+	&__notification {
+		display: block;
+		position: fixed; // Overlay
+		visibility: hidden; // Notifications are hidden by default, and get shown (or animated in) dynamically by the Angular component
+		z-index: 10000; // Pretty much random ...
 
-.x-notifier__container-list {
-	margin: {
-		top: 0;
-		bottom: 0;
+		// This attribute forces this element to be rendered on a new layer, by the GPU, in order to improve its performance (#perfmatters)
+		will-change: transform;
+
+		// This attribute improves the overall scrolling performance for fixed position elements, such as this one (#perfmatters)
+		// See <https://benfrain.com/improving-css-performance-fixed-position-elements/>
+		backface-visibility: hidden;
+
 	}
-	padding: {
-		left: 0;
-	}
-	list-style-type: none;
-}
-
-// Notification
-
-.x-notifier__notification {
-	display: block;
-	position: fixed; // Overlay
-	visibility: hidden; // Notifications are hidden by default, and get shown (or animated in) dynamically by the Angular component
-	z-index: 10000; // Pretty much random ...
-
-	// This attribute forces this element to be rendered on a new layer, by the GPU, in order to improve its performance (#perfmatters)
-	will-change: transform;
-
-	// This attribute improves the overall scrolling performance for fixed position elements, such as this one (#perfmatters)
-	// See <https://benfrain.com/improving-css-performance-fixed-position-elements/>
-	backface-visibility: hidden;
 
 }

--- a/src/lib/styles/themes/theme-material.scss
+++ b/src/lib/styles/themes/theme-material.scss
@@ -4,9 +4,9 @@
 // And, of course, thanks to #Google for creating and sharing such an awesome design language!
 // I highly encourage everyone to read into the Material Design specs: <https://material.google.com/>
 
-$notifier-shadow-color: rgba(0, 0, 0, .2);
+$notifier-shadow-color: rgba(0, 0, 0, .2) !default;
 
-.x-notifier__notification--material {
+.notifier__notification--material {
 	border-radius: 3px;
 	box-shadow: 0 1px 3px $notifier-shadow-color;
 	cursor: default; // Default cursor, even when hovering over text
@@ -15,44 +15,48 @@ $notifier-shadow-color: rgba(0, 0, 0, .2);
 		right: 26px;
 		bottom: 10px;
 		left: 26px;
-	};
-
-	.x-notifier__notification-message {
-		display: inline-block;
-		margin: { // Reset paragraph default styles
-			top: 0;
-			bottom: 0;
-		}
-		vertical-align: top;
-		line-height: 32px;
-		font-size: 15px;
 	}
 
-	.x-notifier__notification-button {
-		display: inline-block;
-		transition: opacity .2s ease;
-		opacity: .5;
-		margin: {
-			right: -10px;
-			left: 10px;
-		};
-		outline: none;
-		border: none;
-		background: none;
-		cursor: pointer; // Make it obvious that the "button" (or, more honestly, icon) is clickable (#UX)
-		padding: 6px;
-		width: 32px;
-		height: 32px;
-		vertical-align: top;
+	.notifier__notification {
 
-		&:hover,
-		&:focus {
-			opacity: 1; // Make me "feel" the clickability with a transparency change (#UX)
+		&-message {
+			display: inline-block;
+			margin: { // Reset paragraph default styles
+				top: 0;
+				bottom: 0;
+			}
+			vertical-align: top;
+			line-height: 32px;
+			font-size: 15px;
 		}
 
-		&:active {
-			transform: scale(.82); // Make me "feel" the click by a push back (#UX)
-			opacity: 1;
+		&-button {
+			display: inline-block;
+			transition: opacity .2s ease;
+			opacity: .5;
+			margin: {
+				right: -10px;
+				left: 10px;
+			};
+			outline: none;
+			border: none;
+			background: none;
+			cursor: pointer; // Make it obvious that the "button" (or, more honestly, icon) is clickable (#UX)
+			padding: 6px;
+			width: 32px;
+			height: 32px;
+			vertical-align: top;
+
+			&:hover,
+			&:focus {
+				opacity: 1; // Make me "feel" the clickability with a transparency change (#UX)
+			}
+
+			&:active {
+				transform: scale(.82); // Make me "feel" the click by a push back (#UX)
+				opacity: 1;
+			}
+
 		}
 
 	}

--- a/src/lib/styles/types/type-default.scss
+++ b/src/lib/styles/types/type-default.scss
@@ -1,14 +1,14 @@
 // NOTIFIER: DEFAULT TYPE STYLES
 
-$notifier-default-background-color: #444;
-$notifier-default-font-color: #FFF;
-$notifier-default-icon-color: #FFF;
+$notifier-default-background-color: #444 !default;
+$notifier-default-font-color: #FFF !default;
+$notifier-default-icon-color: #FFF !default;
 
-.x-notifier__notification--default {
+.notifier__notification--default {
 	background-color: $notifier-default-background-color;
 	color: $notifier-default-font-color;
 
-	.x-notifier__notification-button-icon { // 16x16 fixed size
+	.notifier__notification-button-icon { // 16x16 fixed size
 		fill: $notifier-default-icon-color;
 	}
 

--- a/src/lib/styles/types/type-error.scss
+++ b/src/lib/styles/types/type-error.scss
@@ -1,14 +1,14 @@
 // NOTIFIER: ERROR TYPE STYLES
 
-$notifier-error-background-color: #D9534F;
-$notifier-error-font-color: #FFF;
-$notifier-error-icon-color: #FFF;
+$notifier-error-background-color: #D9534F !default;
+$notifier-error-font-color: #FFF !default;
+$notifier-error-icon-color: #FFF !default;
 
-.x-notifier__notification--error {
+.notifier__notification--error {
 	background-color: $notifier-error-background-color;
 	color: $notifier-error-font-color;
 
-	.x-notifier__notification-button-icon { // 16x16 fixed size
+	.notifier__notification-button-icon { // 16x16 fixed size
 		fill: $notifier-error-icon-color;
 	}
 

--- a/src/lib/styles/types/type-info.scss
+++ b/src/lib/styles/types/type-info.scss
@@ -1,14 +1,14 @@
 // NOTIFIER: INFO TYPE STYLES
 
-$notifier-info-background-color: #5BC0DE;
-$notifier-info-font-color: #FFF;
-$notifier-info-icon-color: #FFF;
+$notifier-info-background-color: #5BC0DE !default;
+$notifier-info-font-color: #FFF !default;
+$notifier-info-icon-color: #FFF !default;
 
-.x-notifier__notification--info {
+.notifier__notification--info {
 	background-color: $notifier-info-background-color;
 	color: $notifier-info-font-color;
 
-	.x-notifier__notification-button-icon { // 16x16 fixed size
+	.notifier__notification-button-icon { // 16x16 fixed size
 		fill: $notifier-info-icon-color;
 	}
 

--- a/src/lib/styles/types/type-success.scss
+++ b/src/lib/styles/types/type-success.scss
@@ -1,14 +1,14 @@
 // NOTIFIER: SUCCESS TYPE STYLES
 
-$notifier-success-background-color: #5CB85C;
-$notifier-success-font-color: #FFF;
-$notifier-success-icon-color: #FFF;
+$notifier-success-background-color: #5CB85C !default;
+$notifier-success-font-color: #FFF !default;
+$notifier-success-icon-color: #FFF !default;
 
-.x-notifier__notification--success {
+.notifier__notification--success {
 	background-color: $notifier-success-background-color;
 	color: $notifier-success-font-color;
 
-	.x-notifier__notification-button-icon { // 16x16 fixed size
+	.notifier__notification-button-icon { // 16x16 fixed size
 		fill: $notifier-success-icon-color;
 	}
 

--- a/src/lib/styles/types/type-warning.scss
+++ b/src/lib/styles/types/type-warning.scss
@@ -1,14 +1,14 @@
 // NOTIFIER: WARNING TYPE STYLES
 
-$notifier-warning-background-color: #F0AD4E;
-$notifier-warning-font-color: #FFF;
-$notifier-warning-icon-color: #FFF;
+$notifier-warning-background-color: #F0AD4E !default;
+$notifier-warning-font-color: #FFF !default;
+$notifier-warning-icon-color: #FFF !default;
 
-.x-notifier__notification--warning {
+.notifier__notification--warning {
 	background-color: $notifier-warning-background-color;
 	color: $notifier-warning-font-color;
 
-	.x-notifier__notification-button-icon { // 16x16 fixed size
+	.notifier__notification-button-icon { // 16x16 fixed size
 		fill: $notifier-warning-icon-color;
 	}
 

--- a/tslint.json
+++ b/tslint.json
@@ -212,13 +212,13 @@
 		"directive-selector": [
 			true,
 			"attribute",
-			"x",
+			"notifier",
 			"camelCase"
 		],
     	"component-selector": [
 			true,
 			"element",
-			"x",
+			"notifier",
 			"kebab-case"
 		],
 		"use-input-property-decorator": true,
@@ -233,7 +233,7 @@
 		"pipe-naming": [
 			true,
 			"camelCase",
-			"x"
+			"notifier"
 		],
 		"component-class-suffix": true,
 		"directive-class-suffix": true,


### PR DESCRIPTION
- Remove "x-" prefix from component selectors
- Remove "x-" prefix from class names
- Add !default to SASS variables
- Improve SASS nesting for better BEM-like structure
- Update TSlint rules

BREAKING CHANGE: Compontent selectors and class name no longer have the "x-" prefix (see MIGRATION GUIDE).