### PR TITLE
refactor(animations): Refactor usage of Web Animations API, add typings

### DIFF
--- a/src/demo/polyfills.ts
+++ b/src/demo/polyfills.ts
@@ -31,4 +31,4 @@ import 'zone.js/dist/zone';
 
 // Web Animations API polyfill
 // -> Required for most browser
-import 'web-animations-js/web-animations-next.min.js';
+import 'web-animations-js';

--- a/src/lib/src/components/notifier-notification.component.spec.ts
+++ b/src/lib/src/components/notifier-notification.component.spec.ts
@@ -16,6 +16,12 @@ import { NotifierTimerService } from '../services/notifier-timer.service';
  */
 describe( 'Notifier Notification Component', () => {
 
+	// tslint:disable no-any
+	const fakeAnimation: any = {
+		onfinish: () => null // We only need this property to be actually mocked away
+	};
+	// tslint:enable no-any
+
 	const testNotification: NotifierNotification = new NotifierNotification( {
 		id: 'ID_FAKE',
 		message: 'Lorem ipsum dolor sit amet.',
@@ -239,16 +245,13 @@ describe( 'Notifier Notification Component', () => {
 
 			// Mock away the Web Animations API
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'opacity' ] = '1'; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'opacity' ] = '1'; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const showCallback: () => {} = jest.fn();
 			componentInstance.show().then( showCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'visibility' ] ).toBe( 'visible' );
@@ -298,16 +301,13 @@ describe( 'Notifier Notification Component', () => {
 
 			// Mock away the Web Animations API
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'opacity' ] = '0'; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'opacity' ] = '0'; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const hideCallback: () => {} = jest.fn();
 			componentInstance.hide().then( hideCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'opacity' ] ).toBe( '0' );
@@ -385,17 +385,14 @@ describe( 'Notifier Notification Component', () => {
 
 			// Mock away the Web Animations API
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'transform' ] =
-							`translate3d( 0, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'transform' ] =
+					`translate3d( 0, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const shiftCallback: () => {} = jest.fn();
 			componentInstance.shift( shiftDistance, true ).then( shiftCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'transform' ] )
@@ -469,17 +466,14 @@ describe( 'Notifier Notification Component', () => {
 			// Mock away the Web Animations API
 			const shiftDistance: number = 100;
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'transform' ] =
-							`translate3d( 0, ${ -shiftDistance - testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'transform' ] =
+					`translate3d( 0, ${ -shiftDistance - testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const shiftCallback: () => {} = jest.fn();
 			componentInstance.shift( shiftDistance, true ).then( shiftCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'transform' ] )
@@ -553,17 +547,14 @@ describe( 'Notifier Notification Component', () => {
 			// Mock away the Web Animations API
 			const shiftDistance: number = 100;
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'transform' ] =
-							`translate3d( 0, ${ -shiftDistance - testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'transform' ] =
+					`translate3d( 0, ${ -shiftDistance - testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const shiftCallback: () => {} = jest.fn();
 			componentInstance.shift( shiftDistance, false ).then( shiftCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'transform' ] )
@@ -637,17 +628,14 @@ describe( 'Notifier Notification Component', () => {
 			// Mock away the Web Animations API
 			const shiftDistance: number = 100;
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'transform' ] =
-							`translate3d( 0, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'transform' ] =
+					`translate3d( 0, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const shiftCallback: () => {} = jest.fn();
 			componentInstance.shift( shiftDistance, false ).then( shiftCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'transform' ] )
@@ -724,17 +712,14 @@ describe( 'Notifier Notification Component', () => {
 			// Mock away the Web Animations API
 			const shiftDistance: number = 100;
 			jest.spyOn( componentFixture.nativeElement, 'animate' ).mockImplementation( () => {
-				return {
-					finished: new Promise<undefined>( ( resolve: () => void, reject: () => void ) => {
-						componentFixture.debugElement.styles[ 'transform' ] =
-							`translate3d( -50%, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
-						resolve();
-					} )
-				};
+				componentFixture.debugElement.styles[ 'transform' ] =
+					`translate3d( -50%, ${ shiftDistance + testNotifierConfig.position.vertical.gap }px, 0 )`; // Fake animation result
+				return fakeAnimation;
 			} );
 
 			const shiftCallback: () => {} = jest.fn();
 			componentInstance.shift( shiftDistance, true ).then( shiftCallback );
+			fakeAnimation.onfinish();
 			tick();
 
 			expect( componentFixture.debugElement.styles[ 'transform' ] )

--- a/src/lib/src/components/notifier-notification.component.ts
+++ b/src/lib/src/components/notifier-notification.component.ts
@@ -71,12 +71,10 @@ export class NotifierNotificationComponent implements AfterViewInit {
 	 */
 	private readonly renderer: Renderer2;
 
-	// tslint:disable no-any
 	/**
 	 * Native element reference, used for manipulating DOM properties
 	 */
-	private readonly element: any; // Similar to an HTMLElement, but also includes web animations properties / methods
-	// tslint:enable no-any
+	private readonly element: HTMLElement;
 
 	/**
 	 * Current notification height, calculated and cached here (#perfmatters)
@@ -183,10 +181,11 @@ export class NotifierNotificationComponent implements AfterViewInit {
 
 				// Animate notification in
 				this.renderer.setStyle( this.element, 'visibility', 'visible' );
-				this.element.animate( animationData.keyframes, animationData.options ).finished.then( () => {
+				const animation: Animation = this.element.animate( animationData.keyframes, animationData.options );
+				animation.onfinish = () => {
 					this.startAutoHideTimer();
 					resolve(); // Done
-				} );
+				};
 
 			} else {
 
@@ -214,7 +213,10 @@ export class NotifierNotificationComponent implements AfterViewInit {
 			// Are animations enabled?
 			if ( this.config.animations.enabled && this.config.animations.hide.speed > 0 ) {
 				const animationData: NotifierAnimationData = this.animationService.getAnimationData( 'hide', this.notification );
-				this.element.animate( animationData.keyframes, animationData.options ).finished.then( resolve ); // Done
+				const animation: Animation = this.element.animate( animationData.keyframes, animationData.options );
+				animation.onfinish = () => {
+					resolve(); // Done
+				};
 			} else {
 				resolve(); // Done
 			}
@@ -260,7 +262,11 @@ export class NotifierNotificationComponent implements AfterViewInit {
 					}
 				};
 				this.elementShift = newElementShift;
-				this.element.animate( animationData.keyframes, animationData.options ).finished.then( resolve ); // Done
+				const animation: Animation = this.element.animate( animationData.keyframes, animationData.options );
+				animation.onfinish = () => {
+					resolve(); // Done
+				};
+
 			} else {
 				this.renderer.setStyle( this.element, 'transform', `translate3d( ${ horizontalPosition }, ${ newElementShift }px, 0 )` );
 				this.elementShift = newElementShift;

--- a/src/lib/src/models/notifier-animation.model.ts
+++ b/src/lib/src/models/notifier-animation.model.ts
@@ -32,12 +32,12 @@ export interface NotifierAnimationData {
 		/**
 		 * Animation easing function (comp. CSS easing functions)
 		 */
-		easing: string;
+		easing?: 'linear' | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | string;
 
 		/**
 		 * Animation fill mode
 		 */
-		fill: string;
+		fill: 'none' | 'forwards' | 'backwards';
 
 	};
 

--- a/src/lib/typings.d.ts
+++ b/src/lib/typings.d.ts
@@ -1,0 +1,76 @@
+/**
+ * This file contains custom typings for this library.
+ *
+ * Sadly, while TypeScript comes with a very rich set of  typings for JavaScript and the DOM, some things are missing, including offset
+ * width & height values on the HTMLElement, the animate() method on the Element plus various Web Animations API related interfaces. To
+ * reduce the amount of 'any' usage in those cases, the following typings are defined to (hopefully only temporarily) help us out.
+ *
+ * Typings related to the Web Animations API are guessed based on the official MDN documentation. They should be complete on the first
+ * level, deeper levels -- and thus functionality not used by this library -- is not typed in further details, but declared as type 'any'.
+ * For details, see <https://developer.mozilla.org/en-US/docs/Web/API/Element/animate>.
+ */
+
+/**
+ * Extended HTMLElement
+ *
+ * We can simply extend the default TypeScript definitions as TypeScript interfaces are *open ended*.
+ * See <https://github.com/basarat/typescript-book/blob/master/docs/types/interfaces.md>.
+ */
+interface HTMLElement {
+	// offsetHeight: number;
+	// offsetWidth: number;
+	animate: ( keyframes: AnimationKeyframes, options?: AnimationOptions | number ) => Animation;
+}
+
+/**
+ * Animation keyframe
+ */
+type AnimationKeyframe = { [ animatablePropertyName: string ]: string };
+
+/**
+ * Animation Keyframes
+ */
+type AnimationKeyframes = Array<AnimationKeyframe>;
+
+/**
+ * Animation options
+ */
+interface AnimationOptions {
+	id?: string;
+	delay?: number;
+	direction?: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
+	duration?: number;
+	easing?: 'linear' | 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | string;
+	endDelay?: number;
+	fill?: 'none' | 'forwards' | 'backwards';
+	iterationStart?: number;
+	iterations?: number;
+}
+
+/**
+ * Animation object, returned by element.animate()
+ */
+interface Animation {
+	currentTime: number | null;
+	// tslint:disable no-any
+	effect: any | null; // No deeper type details needed
+	// tslint:enable no-any
+	readonly finished: Promise<undefined>;
+	id: string | null;
+	readonly playState: 'idle' | 'pending' | 'running' | 'paused' | 'finished';
+	playbackRate: number;
+	readonly ready: Promise<undefined>;
+	startTime: number | null;
+	// tslint:disable no-any
+	timeline: any | null; // No deeper type details needed
+	// tslint:enable no-any
+
+	oncancel: () => void | null;
+	onfinish: () => void | null;
+
+	cancel: () => void;
+	finish: () => void;
+	pause: () => void;
+	play: () => void;
+	reverse: () => void;
+}

--- a/tools/gulp/ts/ts-inline-resources.task.js
+++ b/tools/gulp/ts/ts-inline-resources.task.js
@@ -54,9 +54,8 @@ gulp.task( 'ts:inline-resources', () => {
 
 	return gulp
 		.src( [
-			'src/lib/**/*.ts',
-			'!src/lib/**/*.spec.ts',
-			'!src/lib/**/*.d.ts'
+			'src/lib/**/*.ts', // This includes custom typings
+			'!src/lib/**/*.spec.ts'
 		] )
 		.pipe( inlineTemplate( inlineTemplateOptions ) )
 		.pipe( gulp.dest( 'build/library-inline' ) );

--- a/tools/tsc/tsconfig.es2015.json
+++ b/tools/tsc/tsconfig.es2015.json
@@ -10,7 +10,8 @@
 		"types": []
 	},
 	"files": [
-		"./../../build/library-inline/index.ts"
+		"./../../build/library-inline/index.ts",
+		"./../../build/library-inline/typings.d.ts"
 	],
 	"angularCompilerOptions": {
 		"annotateForClosureCompiler": true,

--- a/tools/tsc/tsconfig.es5.json
+++ b/tools/tsc/tsconfig.es5.json
@@ -9,7 +9,8 @@
 		"types": []
 	},
 	"files": [
-		"./../../build/library-inline/index.ts"
+		"./../../build/library-inline/index.ts",
+		"./../../build/library-inline/typings.d.ts"
 	],
 	"angularCompilerOptions": {
 		"annotateForClosureCompiler": true,


### PR DESCRIPTION
- Refactor the overall usage of the Web Animations API to use the callback instead of the Promise version for getting notified that the animation has finished -- with this change the default "web-animations-js" polyfill will be sufficient
- Add custom typings for the Web Animations API, plus extend the default HTMLElement with the element.animate() method -- more type safety, less usage of 'any'
- Refactor unit tests & demo to reflect the changed described above

Related to #6, #10.