### PR TITLE
docs(README): update demo to Stackblitz example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Demo
 
-You can play around with this library with **[this Plunker right here](https://plnkr.co/edit/b3xiPr?p=preview)**.
+You can play around with this library with **[this Stackblitz right here](https://stackblitz.com/edit/angular-notifier-demo)**.
 
 ![Angular Notifier Animated Preview GIF](/docs/angular-notifier-preview.gif?raw=true)
 


### PR DESCRIPTION
The current Plunkr demo is broken. This is a known problem due to a bad initial configuration of the Angular template on Plunker which did not "freeze" the Angular version that's being fetched from unpkg.com. As a result, changes in the package structure broke a lot of demos.

I created a new demo and ported it to Stackblitz. It's much easier to update the dependencies there (just click the refresh button on the deps panel). And people even have the possibility to export it to a working Angular CLI setup.

You may want to fork my stackblitz and adjust the URL to be able to update it in the future.