### PR TITLE
fix(notifier): Fix circular dependency issues of injection tokens

### DIFF
--- a/src/lib/src/components/notifier-container.component.spec.ts
+++ b/src/lib/src/components/notifier-container.component.spec.ts
@@ -2,7 +2,7 @@ import { By } from '@angular/platform-browser';
 import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { NotifierConfigToken } from '../notifier.module';
+import { NotifierConfigToken } from '../notifier-token';
 import { NotifierAction } from '../models/notifier-action.model';
 import { NotifierConfig } from '../models/notifier-config.model';
 import { NotifierQueueService } from '../services/notifier-queue.service';

--- a/src/lib/src/components/notifier-notification.component.spec.ts
+++ b/src/lib/src/components/notifier-notification.component.spec.ts
@@ -2,7 +2,7 @@ import { DebugElement, Component, ViewChild, NO_ERRORS_SCHEMA, TemplateRef } fro
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, fakeAsync, TestBed, tick, async } from '@angular/core/testing';
 
-import { NotifierConfigToken } from '../notifier.module';
+import { NotifierConfigToken } from '../notifier-token';
 import { NotifierAnimationData } from '../models/notifier-animation.model';
 import { NotifierNotification } from '../models/notifier-notification.model';
 import { NotifierConfig } from '../models/notifier-config.model';

--- a/src/lib/src/notifier-token.ts
+++ b/src/lib/src/notifier-token.ts
@@ -1,0 +1,19 @@
+import { NotifierConfig, NotifierOptions } from './models/notifier-config.model';
+import { InjectionToken } from '@angular/core';
+
+// tslint:disable variable-name
+
+/**
+ * Injection Token for notifier options
+ */
+export const NotifierOptionsToken: InjectionToken<NotifierOptions>
+	= new InjectionToken<NotifierOptions>( '[angular-notifier] Notifier Options' );
+
+/**
+ * Injection Token for notifier configuration
+ */
+export const NotifierConfigToken: InjectionToken<NotifierConfig>
+	= new InjectionToken<NotifierConfig>( '[anuglar-notifier] Notifier Config' );
+
+// tslint:enable variable-name
+

--- a/src/lib/src/notifier.module.ts
+++ b/src/lib/src/notifier.module.ts
@@ -7,22 +7,7 @@ import { NotifierConfig, NotifierOptions } from './models/notifier-config.model'
 import { NotifierAnimationService } from './services/notifier-animation.service';
 import { NotifierQueueService } from './services/notifier-queue.service';
 import { NotifierService } from './services/notifier.service';
-
-// tslint:disable variable-name
-
-/**
- * Injection Token for notifier options
- */
-export const NotifierOptionsToken: InjectionToken<NotifierOptions>
-	= new InjectionToken<NotifierOptions>( '[angular-notifier] Notifier Options' );
-
-/**
- * Injection Token for notifier configuration
- */
-export const NotifierConfigToken: InjectionToken<NotifierConfig>
-	= new InjectionToken<NotifierConfig>( '[anuglar-notifier] Notifier Config' );
-
-// tslint:enable variable-name
+import { NotifierConfigToken, NotifierOptionsToken } from './notifier-token';
 
 /**
  * Factory for a notifier configuration with custom options

--- a/src/lib/src/services/notifier.service.spec.ts
+++ b/src/lib/src/services/notifier.service.spec.ts
@@ -1,6 +1,6 @@
 import { inject, TestBed } from '@angular/core/testing';
 
-import { NotifierConfigToken } from '../notifier.module';
+import { NotifierConfigToken } from '../notifier-token';
 import { NotifierConfig } from '../models/notifier-config.model';
 import { NotifierNotificationOptions } from '../models/notifier-notification.model';
 import { NotifierAction } from '../models/notifier-action.model';

--- a/src/lib/src/services/notifier.service.ts
+++ b/src/lib/src/services/notifier.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, forwardRef } from '@angular/core';
 import { NotifierConfig } from './../models/notifier-config.model';
 import { NotifierNotificationOptions } from './../models/notifier-notification.model';
 import { NotifierQueueService } from './notifier-queue.service';
-import { NotifierConfigToken } from './../notifier.module';
+import { NotifierConfigToken } from './../notifier-token';
 
 /**
  * Notifier service
@@ -33,7 +33,7 @@ export class NotifierService {
 	 */
 	public constructor(
 		notifierQueueService: NotifierQueueService,
-		@Inject( forwardRef( () => NotifierConfigToken ) ) config: NotifierConfig // The forwardRef is (sadly) required here
+		@Inject(NotifierConfigToken) config: NotifierConfig
 	) {
 		this.queueService = notifierQueueService;
 		this.config = config;


### PR DESCRIPTION
Resolves the circular dependency created when the injection tokens are imported in the notifier.service by extracting the tokens to their own file.

This especially caused problems with the new Ivy renderer in the Angular 8.0.0-beta.13.