### PR TITLE
Expose actionStream in Notifier Service

### DIFF
--- a/projects/angular-notifier/src/lib/services/notifier.service.spec.ts
+++ b/projects/angular-notifier/src/lib/services/notifier.service.spec.ts
@@ -1,4 +1,5 @@
 import { inject, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
 
 import { NotifierAction } from '../models/notifier-action.model';
 import { NotifierConfig } from '../models/notifier-config.model';
@@ -170,6 +171,16 @@ describe('Notifier Service', () => {
   it('should return the configuration', () => {
     expect(service.getConfig()).toEqual(testNotifierConfig);
   });
+
+  it('should return the notification action', () => {
+    const testNotificationId = 'ID_FAKE';
+    const expectedAction: NotifierAction = {
+      payload: testNotificationId,
+      type: 'HIDE',
+    };
+    service.actionStream.subscribe((action) => expect(action).toEqual(expectedAction));
+    service.hide(testNotificationId);
+  });
 });
 
 /**
@@ -180,6 +191,7 @@ class MockNotifierQueueService extends NotifierQueueService {
    * Last action
    */
   public lastAction: NotifierAction;
+  public actionStream = new Subject<NotifierAction>();
 
   /**
    * Push a new action to the queue
@@ -190,5 +202,6 @@ class MockNotifierQueueService extends NotifierQueueService {
    */
   public push(action: NotifierAction): void {
     this.lastAction = action;
+    this.actionStream.next(action);
   }
 }

--- a/projects/angular-notifier/src/lib/services/notifier.service.ts
+++ b/projects/angular-notifier/src/lib/services/notifier.service.ts
@@ -1,5 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
+import { NotifierAction } from '../models/notifier-action.model';
 import { NotifierConfig } from '../models/notifier-config.model';
 import { NotifierNotificationOptions } from '../models/notifier-notification.model';
 import { NotifierConfigToken } from '../notifier.tokens';
@@ -42,6 +44,15 @@ export class NotifierService {
    */
   public getConfig(): NotifierConfig {
     return this.config;
+  }
+
+  /**
+   * Get the observable for handling actions
+   *
+   * @returns Observable of NotifierAction
+   */
+  public get actionStream(): Observable<NotifierAction> {
+    return this.queueService.actionStream.asObservable();
   }
 
   /**


### PR DESCRIPTION
Thanks for the package.
I would like to listen to the actions.
This will help me enable my handlers, such as playing sounds when a certain notification appears or finding out that the user has closed the notification without creating a custom template for notifications.